### PR TITLE
Notification body from random list item

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -120,7 +120,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         DefaultStyleInformation defaultStyleInformation = (DefaultStyleInformation) notificationDetails.styleInformation;
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, notificationDetails.channelId)
                 .setContentTitle(defaultStyleInformation.htmlFormatTitle ? fromHtml(notificationDetails.title) : notificationDetails.title)
-                .setContentText(defaultStyleInformation.htmlFormatBody ? fromHtml(notificationDetails.body) : notificationDetails.body)
+                .setContentText(defaultStyleInformation.htmlFormatBody ? fromHtml(notificationDetails.getBody()) : notificationDetails.getBody())
                 .setTicker(notificationDetails.ticker)
                 .setAutoCancel(BooleanUtils.getValue(notificationDetails.autoCancel))
                 .setContentIntent(pendingIntent)

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -15,7 +15,9 @@ import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 public class NotificationDetails {
     private static final String PAYLOAD = "payload";
@@ -102,7 +104,7 @@ public class NotificationDetails {
 
     public Integer id;
     public String title;
-    public String body;
+    public Object body;
     public String icon;
     public String channelId = "Default_Channel_Id";
     public String channelName;
@@ -144,6 +146,21 @@ public class NotificationDetails {
     public String ticker;
     public Boolean allowWhileIdle;
 
+    public String getBody() {
+        String body;
+        if (this.body instanceof List) {
+            try {
+                List<String> bodies = (List<String>) this.body;
+                int bodyPosition = new Random().nextInt() % bodies.size();
+                body = bodies.get(bodyPosition < 0 ? -bodyPosition : bodyPosition);
+            } catch (Exception e) {
+                body = "";
+            }
+        } else {
+            body = (String) this.body;
+        }
+        return body;
+    }
 
     // Note: this is set on the Android to save details about the icon that should be used when re-hydrating scheduled notifications when a device has been restarted.
     public Integer iconResourceId;
@@ -153,7 +170,7 @@ public class NotificationDetails {
         notificationDetails.payload = (String) arguments.get(PAYLOAD);
         notificationDetails.id = (Integer) arguments.get(ID);
         notificationDetails.title = (String) arguments.get(TITLE);
-        notificationDetails.body = (String) arguments.get(BODY);
+        notificationDetails.body = arguments.get(BODY);
         if (arguments.containsKey(MILLISECONDS_SINCE_EPOCH)) {
             notificationDetails.millisecondsSinceEpoch = (Long) arguments.get(MILLISECONDS_SINCE_EPOCH);
         }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,12 @@ class _HomePageState extends State<HomePage> {
                     },
                   ),
                   PaddedRaisedButton(
+                    buttonText: 'Show notification every minute with body from array',
+                    onPressed: () async {
+                      await _repeatEveryMinuteNotificationFromArray(1);
+                    },
+                  ),
+                  PaddedRaisedButton(
                     buttonText: 'Show notification every 2 days at 12:00',
                     onPressed: () async {
                       await _repeatEveryDaysAtTimeNotification(2, Time(12, 0, 0));
@@ -582,6 +588,26 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating every $minutes minutes title',
         'repeating every $minutes minutes body', RepeatInterval.EveryMinute, platformChannelSpecifics,
+        multiplyInterval: minutes);
+  }
+
+  Future<void> _repeatEveryMinuteNotificationFromArray(int minutes) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'repeating channel id',
+        'repeating channel name',
+        'repeating description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    final bodies = [
+      'repeating body 1',
+      'repeating body 2',
+      'repeating body 3',
+      'repeating body 4',
+      'repeating body 5'
+    ];
+    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating every $minutes minutes title',
+        bodies, RepeatInterval.EveryMinute, platformChannelSpecifics,
         multiplyInterval: minutes);
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -244,7 +244,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', 'plain body', platformChannelSpecifics,
+        0, NotificationContent('plain title', 'plain body'), platformChannelSpecifics,
         payload: 'item x');
   }
 
@@ -282,8 +282,8 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.schedule(
         0,
-        'scheduled title',
-        'scheduled body',
+        NotificationContent('scheduled title',
+        'scheduled body'),
         scheduledNotificationDateTime,
         platformChannelSpecifics);
   }
@@ -299,8 +299,8 @@ class _HomePageState extends State<HomePage> {
         IOSNotificationDetails(presentSound: false);
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, '<b>silent</b> title',
-        '<b>silent</b> body', platformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, NotificationContent('<b>silent</b> title',
+        '<b>silent</b> body'), platformChannelSpecifics);
   }
 
   Future<String> _downloadAndSaveImage(String url, String fileName) async {
@@ -334,7 +334,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
+        0, NotificationContent('big text title', 'silent body'), platformChannelSpecifics);
   }
 
   Future<void> _showBigPictureNotificationHideExpandedLargeIcon() async {
@@ -360,7 +360,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
+        0, NotificationContent('big text title', 'silent body'), platformChannelSpecifics);
   }
 
   Future<void> _showBigTextNotification() async {
@@ -380,7 +380,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
+        0, NotificationContent('big text title', 'silent body'), platformChannelSpecifics);
   }
 
   Future<void> _showInboxNotification() async {
@@ -400,7 +400,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        0, 'inbox title', 'inbox body', platformChannelSpecifics);
+        0, NotificationContent('inbox title', 'inbox body'), platformChannelSpecifics);
   }
 
   Future<void> _showMessagingNotification() async {
@@ -454,14 +454,14 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        0, 'message title', 'message body', platformChannelSpecifics);
+        0, NotificationContent('message title', 'message body'), platformChannelSpecifics);
 
     // wait 10 seconds and add another message to simulate another response
     await Future.delayed(Duration(seconds: 10), () async {
       messages.add(
           Message('Thai', DateTime.now().add(Duration(minutes: 11)), null));
       await flutterLocalNotificationsPlugin.show(
-          0, 'message title', 'message body', platformChannelSpecifics);
+          0, NotificationContent('message title', 'message body'), platformChannelSpecifics);
     });
   }
 
@@ -478,8 +478,8 @@ class _HomePageState extends State<HomePage> {
         groupKey: groupKey);
     var firstNotificationPlatformSpecifics =
         NotificationDetails(firstNotificationAndroidSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(1, 'Alex Faarborg',
-        'You will not believe...', firstNotificationPlatformSpecifics);
+    await flutterLocalNotificationsPlugin.show(1, NotificationContent('Alex Faarborg',
+        'You will not believe...'), firstNotificationPlatformSpecifics);
     var secondNotificationAndroidSpecifics = AndroidNotificationDetails(
         groupChannelId, groupChannelName, groupChannelDescription,
         importance: Importance.Max,
@@ -489,8 +489,8 @@ class _HomePageState extends State<HomePage> {
         NotificationDetails(secondNotificationAndroidSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
         2,
-        'Jeff Chang',
-        'Please join us to celebrate the...',
+        NotificationContent('Jeff Chang',
+        'Please join us to celebrate the...'),
         secondNotificationPlatformSpecifics);
 
     // create the summary notification required for older devices that pre-date Android 7.0 (API level 24)
@@ -508,7 +508,7 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
     await flutterLocalNotificationsPlugin.show(
-        3, 'Attention', 'Two messages', platformChannelSpecifics);
+        3, NotificationContent('Attention', 'Two messages'), platformChannelSpecifics);
   }
 
   Future<void> _checkPendingNotificationRequests() async {
@@ -562,8 +562,8 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, 'ongoing notification title',
-        'ongoing notification body', platformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, NotificationContent('ongoing notification title',
+        'ongoing notification body'), platformChannelSpecifics);
   }
 
   Future<void> _repeatNotification() async {
@@ -574,8 +574,12 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating title',
-        'repeating body', RepeatInterval.EveryMinute, platformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.periodicallyShow(
+        0,
+        NotificationContent('repeating title', 'repeating body'),
+        RepeatInterval.EveryMinute,
+        platformChannelSpecifics
+    );
   }
 
   Future<void> _repeatEveryMinuteNotification(int minutes) async {
@@ -586,19 +590,25 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating every $minutes minutes title',
-        'repeating every $minutes minutes body', RepeatInterval.EveryMinute, platformChannelSpecifics,
-        multiplyInterval: minutes);
+    await flutterLocalNotificationsPlugin.periodicallyShow(
+        0,
+        NotificationContent('repeating every $minutes minutes title', 'repeating every $minutes minutes body'),
+        RepeatInterval.EveryMinute,
+        platformChannelSpecifics,
+        multiplyInterval: minutes
+    );
   }
 
   Future<void> _repeatEveryMinuteNotificationFromArray(int minutes) async {
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'repeating channel id',
         'repeating channel name',
-        'repeating description');
+        'repeating description'
+    );
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics
+    );
     final bodies = [
       'repeating body 1',
       'repeating body 2',
@@ -606,9 +616,13 @@ class _HomePageState extends State<HomePage> {
       'repeating body 4',
       'repeating body 5'
     ];
-    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating every $minutes minutes title',
-        bodies, RepeatInterval.EveryMinute, platformChannelSpecifics,
-        multiplyInterval: minutes);
+    await flutterLocalNotificationsPlugin.periodicallyShow(
+        0,
+        NotificationContent.withBodyAsList('repeating every $minutes minutes title', bodies),
+        RepeatInterval.EveryMinute,
+        platformChannelSpecifics,
+        multiplyInterval: minutes
+    );
   }
 
   Future<void> _repeatEveryDaysAtTimeNotification(int days, Time time) async {
@@ -619,8 +633,13 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.showEveryFewDaysAtTime(0, 'repeating daily at time title',
-        'repeating daily at time body', platformChannelSpecifics, time, multiplyInterval: days);
+    await flutterLocalNotificationsPlugin.showEveryFewDaysAtTime(
+        0,
+        NotificationContent('repeating daily at time title', 'repeating daily at time body'),
+        platformChannelSpecifics,
+        time,
+        multiplyInterval: days
+    );
   }
 
   Future<void> _showDailyAtTime() async {
@@ -634,10 +653,10 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.showDailyAtTime(
         0,
-        'show daily title',
-        'Daily notification shown at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        NotificationContent('show daily title', 'Daily notification shown at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}'),
         time,
-        platformChannelSpecifics);
+        platformChannelSpecifics
+    );
   }
 
   Future<void> _showWeeklyAtDayAndTime() async {
@@ -651,11 +670,11 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
         0,
-        'show weekly title',
-        'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        NotificationContent('show weekly title', 'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}'),
         Day.Monday,
         time,
-        platformChannelSpecifics);
+        platformChannelSpecifics
+    );
   }
 
   Future<void> _showNotificationWithNoBadge() async {
@@ -669,8 +688,11 @@ class _HomePageState extends State<HomePage> {
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
-        0, 'no badge title', 'no badge body', platformChannelSpecifics,
-        payload: 'item x');
+        0,
+        NotificationContent('no badge title', 'no badge body'),
+        platformChannelSpecifics,
+        payload: 'item x'
+    );
   }
 
   Future<void> _showProgressNotification() async {
@@ -693,10 +715,13 @@ class _HomePageState extends State<HomePage> {
             androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
         await flutterLocalNotificationsPlugin.show(
             0,
-            'progress notification title',
-            'progress notification body',
+            NotificationContent(
+                'progress notification title',
+                'progress notification body'
+            ),
             platformChannelSpecifics,
-            payload: 'item x');
+            payload: 'item x'
+        );
       });
     }
   }
@@ -717,10 +742,13 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
         0,
-        'indeterminate progress notification title',
-        'indeterminate progress notification body',
+        NotificationContent(
+            'indeterminate progress notification title',
+            'indeterminate progress notification body'
+        ),
         platformChannelSpecifics,
-        payload: 'item x');
+        payload: 'item x'
+    );
   }
 
   Future<void> _showNotificationWithUpdatedChannelDescription() async {
@@ -736,10 +764,13 @@ class _HomePageState extends State<HomePage> {
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
         0,
-        'updated notification channel',
-        'check settings to see updated channel description',
+        NotificationContent(
+            'updated notification channel',
+            'check settings to see updated channel description'
+        ),
         platformChannelSpecifics,
-        payload: 'item x');
+        payload: 'item x'
+    );
   }
 
   String _toTwoDigitString(int value) {

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -192,7 +192,13 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     NotificationDetails *notificationDetails = [[NotificationDetails alloc]init];
     notificationDetails.id = call.arguments[ID];
     notificationDetails.title = call.arguments[TITLE];
-    notificationDetails.body = call.arguments[BODY];
+    if ([call.arguments[BODY] isKindOfClass:[NSMutableArray class]]) {
+        NSMutableArray *bodies = [call.arguments mutableArrayValueForKey:BODY];
+        NSInteger randPosition = rand() % bodies.count;
+        notificationDetails.body = bodies[randPosition];
+    } else {
+        notificationDetails.body = call.arguments[BODY];
+    }
     notificationDetails.payload = call.arguments[PAYLOAD];
     notificationDetails.presentAlert = displayAlert;
     notificationDetails.presentSound = playSound;

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -62,6 +62,21 @@ class Time {
   }
 }
 
+class NotificationContent {
+
+  final String title;
+  final Object body;
+
+  NotificationContent._internal(this.title, this.body);
+
+  NotificationContent(this.title, String body) : this.body = body;
+
+  factory NotificationContent.withBodyAsList(String title, List<String> body) {
+    return NotificationContent._internal(title, body);
+  }
+  
+}
+
 class FlutterLocalNotificationsPlugin {
   factory FlutterLocalNotificationsPlugin() => _instance;
 
@@ -111,7 +126,7 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Show a notification with an optional payload that will be passed back to the app when a notification is tapped
-  Future<void> show(int id, String title, String body,
+  Future<void> show(int id, NotificationContent content,
       NotificationDetails notificationDetails,
       {String payload}) async {
     _validateId(id);
@@ -119,8 +134,8 @@ class FlutterLocalNotificationsPlugin {
     _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('show', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
     });
@@ -140,7 +155,7 @@ class FlutterLocalNotificationsPlugin {
   /// Schedules a notification to be shown at the specified time with an optional payload that is passed through when a notification is tapped
   /// The [androidAllowWhileIdle] parameter is Android-specific and determines if the notification should still be shown at the specified time
   /// even when in a low-power idle mode.
-  Future<void> schedule(int id, String title, String body,
+  Future<void> schedule(int id, NotificationContent content,
       DateTime scheduledDate, NotificationDetails notificationDetails,
       {String payload, bool androidAllowWhileIdle = false}) async {
     _validateId(id);
@@ -151,8 +166,8 @@ class FlutterLocalNotificationsPlugin {
     }
     await _channel.invokeMethod('schedule', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'millisecondsSinceEpoch': scheduledDate.millisecondsSinceEpoch,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
@@ -163,7 +178,7 @@ class FlutterLocalNotificationsPlugin {
   /// For example, specifying a hourly interval means the first time the notification will be an hour after the method has been called and then every hour after that.
   /// [multiplyInterval] scales intervals. For example, if [repeatInterval] equals [RepeatInterval.Daily]
   /// and [multiplyInterval] equals 3, the total interval will be 3 days
-  Future<void> periodicallyShow(int id, String title, Object body,
+  Future<void> periodicallyShow(int id, NotificationContent content,
       RepeatInterval repeatInterval, NotificationDetails notificationDetails,
       {String payload, int multiplyInterval = 1}) async {
     _validateId(id);
@@ -171,8 +186,8 @@ class FlutterLocalNotificationsPlugin {
     _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'calledAt': DateTime
           .now()
           .millisecondsSinceEpoch,
@@ -184,15 +199,15 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Same as [FlutterLocalNotificationsPlugin.periodicallyShow] with additional parameter [notificationTime]
-  Future<void> showEveryFewDaysAtTime(int id, String title, Object body,
+  Future<void> showEveryFewDaysAtTime(int id, NotificationContent content,
       NotificationDetails notificationDetails, Time notificationTime,
       {String payload, int multiplyInterval = 1}) async {
     _validateId(id);
     var serializedPlatformSpecifics = _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'calledAt': DateTime.now().millisecondsSinceEpoch,
       'repeatInterval': RepeatInterval.Daily.index,
       'repeatTime': notificationTime.toMap(),
@@ -203,7 +218,7 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Shows a notification on a daily interval at the specified time
-  Future<void> showDailyAtTime(int id, String title, String body,
+  Future<void> showDailyAtTime(int id, NotificationContent content,
       Time notificationTime, NotificationDetails notificationDetails,
       {String payload}) async {
     _validateId(id);
@@ -211,8 +226,8 @@ class FlutterLocalNotificationsPlugin {
     _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('showDailyAtTime', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'calledAt': DateTime
           .now()
           .millisecondsSinceEpoch,
@@ -224,7 +239,7 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Shows a notification on a daily interval at the specified time
-  Future<void> showWeeklyAtDayAndTime(int id, String title, String body,
+  Future<void> showWeeklyAtDayAndTime(int id, NotificationContent content,
       Day day, Time notificationTime, NotificationDetails notificationDetails,
       {String payload}) async {
     _validateId(id);
@@ -232,8 +247,8 @@ class FlutterLocalNotificationsPlugin {
     _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('showWeeklyAtDayAndTime', <String, dynamic>{
       'id': id,
-      'title': title,
-      'body': body,
+      'title': content.title,
+      'body': content.body,
       'calledAt': DateTime
           .now()
           .millisecondsSinceEpoch,

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -163,7 +163,7 @@ class FlutterLocalNotificationsPlugin {
   /// For example, specifying a hourly interval means the first time the notification will be an hour after the method has been called and then every hour after that.
   /// [multiplyInterval] scales intervals. For example, if [repeatInterval] equals [RepeatInterval.Daily]
   /// and [multiplyInterval] equals 3, the total interval will be 3 days
-  Future<void> periodicallyShow(int id, String title, String body,
+  Future<void> periodicallyShow(int id, String title, Object body,
       RepeatInterval repeatInterval, NotificationDetails notificationDetails,
       {String payload, int multiplyInterval = 1}) async {
     _validateId(id);
@@ -184,7 +184,7 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Same as [FlutterLocalNotificationsPlugin.periodicallyShow] with additional parameter [notificationTime]
-  Future<void> showEveryFewDaysAtTime(int id, String title, String body,
+  Future<void> showEveryFewDaysAtTime(int id, String title, Object body,
       NotificationDetails notificationDetails, Time notificationTime,
       {String payload, int multiplyInterval = 1}) async {
     _validateId(id);

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -34,7 +34,7 @@ void main() {
           NotificationDetails(null, iOSPlatformChannelSpecifics);
 
       await flutterLocalNotificationsPlugin
-          .show(0, title, body, platformChannelSpecifics, payload: payload);
+          .show(0, NotificationContent(title, body), platformChannelSpecifics, payload: payload);
       verify(mockChannel.invokeMethod('show', <String, dynamic>{
         'id': id,
         'title': title,
@@ -50,7 +50,7 @@ void main() {
           IOSNotificationDetails();
       NotificationDetails platformChannelSpecifics =
           NotificationDetails(null, iOSPlatformChannelSpecifics);
-      await flutterLocalNotificationsPlugin.schedule(id, title, body,
+      await flutterLocalNotificationsPlugin.schedule(id, NotificationContent(title, body),
           scheduledNotificationDateTime, platformChannelSpecifics);
       verify(mockChannel.invokeMethod('schedule', <String, dynamic>{
         'id': id,
@@ -94,7 +94,7 @@ void main() {
           NotificationDetails(androidPlatformChannelSpecifics, null);
 
       await flutterLocalNotificationsPlugin
-          .show(0, title, body, platformChannelSpecifics, payload: payload);
+          .show(0, NotificationContent(title, body), platformChannelSpecifics, payload: payload);
       verify(mockChannel.invokeMethod('show', <String, dynamic>{
         'id': id,
         'title': title,
@@ -115,7 +115,7 @@ void main() {
           NotificationDetails(androidPlatformChannelSpecifics, null);
       var androidPlatformChannelSpecificsMap = androidPlatformChannelSpecifics.toMap();
       androidPlatformChannelSpecificsMap['allowWhileIdle'] = false;
-      await flutterLocalNotificationsPlugin.schedule(id, title, body,
+      await flutterLocalNotificationsPlugin.schedule(id, NotificationContent(title, body),
           scheduledNotificationDateTime, platformChannelSpecifics);
       verify(mockChannel.invokeMethod('schedule', <String, dynamic>{
         'id': id,


### PR DESCRIPTION
Plugin accepts list of strings as body parameter. Every notification shows random item from the list if body is a list of strings. This feature is useful if you need to schedule repeated notifications with random text.

Currently is implemented correctly only for Android platform - iOS takes random value from list only for first notification and next notifications use same text of body.